### PR TITLE
Included Kibana URL in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
         -Des.password=
         -Dgeonetwork.ESFeaturesProxy.targetUri=http://elasticsearch:9200/gn-features/{_}
         -Dgeonetwork.HttpDashboardProxy.targetUri=${KIBANA_URL}
+        -Dkb.url=${KIBANA_URL}
 
       GEONETWORK_DB_TYPE: ${GEONETWORK_DB_TYPE}
       GEONETWORK_DB_HOST: ${GEONETWORK_DB_HOST}


### PR DESCRIPTION
This config parameter is needed for avoiding errors on launching. 

See also: https://github.com/docker-library/docs/tree/master/geonetwork#java-properties-version-440-and-newer

Fixes #1 